### PR TITLE
Change store creation code to be more idiomatic

### DIFF
--- a/store/configureStore.js
+++ b/store/configureStore.js
@@ -1,15 +1,18 @@
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import createLogger from 'redux-logger';
-import exerciseApp from '../reducers';
-
-const createStoreWithMiddleware = applyMiddleware(
-    thunkMiddleware,
-    createLogger()
-)(createStore);
+import rootReducer from '../reducers';
 
 export default function configureStore(initialState) {
-    const store = createStoreWithMiddleware(exerciseApp, initialState);
+    const middleware = [
+        thunkMiddleware,
+        createLogger(),
+    ];
+
+    const store = createStore(rootReducer, initialState, compose(
+        applyMiddleware(...middleware),
+        window.devToolsExtension ? window.devToolsExtension() : func => func
+    ));
 
     if (module.hot) {
         // Enable Webpack hot module replacement for reducers


### PR DESCRIPTION
Sorry for the methodology, those are too many changes for a single commit but I don't really have the time to break them down properly. Feel free to reject the PR and add the changes you think are relevant if appropriate.

Changes:

1) `import exerciseApp from '../reducers';` – `exerciseApp` renamed to `rootReducer`. 

In this part of the code, "exerciseApp" isn't the right level of abstraction: this code is very redux specific, so let’s use redux keywords everywhere and keep it looking like the boilerplate it is. middleware, reducers and stores are what you manipulate _within this part of the code_.

2) Store enhancer code changed to the more idiomatic `createStore(reducer, state, applyMiddleware(`. This is the preferred way to apply the middleware, and it has two benefits:
- Avoids confusing chained function calls (`middleware()(createStore)(exerciseApp, initialState)`
- Removes intermediate "createStoreWithMiddleware" function

I also added the `...middlewares` destructuring so that we keep the "configuration" (active middlewares list) separate from the "code" (`applyMiddleware` code).

3) Add binding to the redux devtools extension (https://github.com/zalmoxisus/redux-devtools-extension#2-use-with-redux).

This is just a nice Chrome extension to use when working with Redux, and allows you to keep your console.log for what _you_ want to see.
