### PR TITLE
Clean up app bootstrap code

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,19 @@
-// This is the "root" of your App
-// It's basically wrapping the App component inside a Provider component which will
-// ensure that the app store is accessible across all the app
-// Meet me in /components/App.js
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
 
-import 'babel-polyfill'
-import React from 'react'
-import { render } from 'react-dom'
-import { Provider } from 'react-redux'
 import configureStore from './store/configureStore';
-import { createStore } from 'redux'
-import App from './components/App'
+import App from './components/App';
 
 const store = configureStore();
 
-render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
-  document.getElementById('root')
-)
+// This is the "root" of your React App
+// The render function bootstraps React onto the page, in a specific element (#root).
+// A Redux Provider component is wrapping <App /> to provide access to the Redux store.
+// Meet me in /components/App.js
+ReactDOM.render(
+    <Provider store={store}>
+        <App />
+    </Provider>,
+    document.getElementById('root')
+);


### PR DESCRIPTION
1) Remove `babel-polyfill`. This is a bad habit that shouldn't be pushed for, as it has a very high cost on performance and bundle size compared to other "ES6 goodies".

2) Use less idiomatic `ReactDOM.render(`. My personal taste. I think it makes it easier to understand what's going on if you are new to React.

3) Styleguide clean up. This matters a lot if we want people to focus on the Redux code.

4) Comment changes.

A bit arbitrary – I think the important things to convey here is that this is just the root of "React" – there might be other parts to the app. Also changed the part about the Provider to make sure it's clear it's a Redux thing.

Side note @vincentaudebert : this would be the right place to explain the relation between `redux` and the `react-redux` bindings.
