### PR TITLE
Add Springload ESLint configuration following Airbnb

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,24 @@
+{
+    "extends": "airbnb",
+
+    "rules": {
+        "indent": [2, 4],
+        "max-len": [1, 120, 4, {"ignoreUrls": true}],
+        "id-length": [1, {"min": 2, "exceptions": ["x", "y", "e", "i", "j", "k", "d", "n", "_", "$"]}],
+        "object-shorthand": [2, "methods"],
+        "arrow-body-style": [0],
+        "no-new": [1],
+        "no-multi-spaces": [0],
+        "no-warning-comments": [1, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
+        "react/sort-comp": [0],
+        "react/jsx-boolean-value": [0],
+        "react/jsx-no-bind": [0],
+        "react/prefer-es6-class": [0, 'never'],
+        "react/jsx-indent-props": [2, 4],
+        "jsx-quotes": [1, "prefer-double"]
+    },
+
+    "env": {
+        "mocha": true
+    }
+}


### PR DESCRIPTION
Even if there's no tooling for linting within the exercise, there should still be a configuration for people that do have the tooling globally installed.

And the code should still follow the styleguide, as it makes it easier for people to concentrate on what matters (Redux) if they aren't put off by stylistic differences.
